### PR TITLE
Make string conversion be idomatic

### DIFF
--- a/src/nimpath.nim
+++ b/src/nimpath.nim
@@ -56,7 +56,7 @@ iterator query*(xpath_expr: string, xpath_ctx : xmlXPathContextPtr): HTMLNode =
 
   if nodes.nodeNr > 0:
     for i in (0..(nodes.nodeNr-1)):
-      currentNode = cast[ptr xmlNodePtr](cast[int](nodes.nodeTab) + cast[int](i * nodes.nodeTab.sizeof))      
+      currentNode = cast[ptr xmlNodePtr](cast[int](nodes.nodeTab) + cast[int](i * nodes.nodeTab.sizeof))
       yield HTMLNode(node_name: stringOpt $currentNode[].name, node: currentNode[], context: xpath_ctx)
 
 iterator queryWithContext*(node: HTMLNode, xpath_expr: string) : HTMLNode =

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -20,7 +20,7 @@ test "xpathQuery works with file":
     var subnode = getSingleWithContext(node, "span")
     if subnode.isSome:
       assert $subnode.get.textContent.get == "this is a span"
-    if node.node.name == "h1":
+    if $node.node.name == "h1":
       let expected_attrs = @[(name: "id", value: "some_id"), (name: "class", value: "header1")]
       let actual_attrs = toSeq(node.getAttributes)
       assert expected_attrs == actual_attrs


### PR DESCRIPTION
Saw someone get this error `nimpath.nim(43, 29) Error: undeclared field: 'cstringToNim'` and was curious so I investigated.

Issue was that `cstringToNim` expected `cstring` but it was given a `ptr xmlchar` (And since it was using field access notation, the error said undeclared field instead of type mismatch`)

This updates the code to use `$` instead which is what Nim code usually uses to convert something to `string`.

Tests all pass for me