### PR TITLE
Free `xpath_obj` after use

### DIFF
--- a/src/nimpath.nim
+++ b/src/nimpath.nim
@@ -57,7 +57,8 @@ iterator query*(xpath_expr: string, xpath_ctx : xmlXPathContextPtr): HTMLNode =
     for i in (0..(nodes.nodeNr-1)):
       currentNode = cast[ptr xmlNodePtr](cast[int](nodes.nodeTab) + cast[int](i * nodes.nodeTab.sizeof))
       yield HTMLNode(node_name: cstringToNim(currentNode[].name), node: currentNode[], context: xpath_ctx)
-
+  xmlFree xpath_obj
+  
 iterator queryWithContext*(node: HTMLNode, xpath_expr: string) : HTMLNode =
   discard xmlXPathSetContextNode(node.node, node.context)
   for node in query(xpath_expr, node.context):


### PR DESCRIPTION
Ran valgrind and there are a few leaks. Couldn't track down all of them but did track down one leak to the `xpath_obj` not getting freed

Relevant output from valgrind
**before**
```
==17332== 168 (72 direct, 96 indirect) bytes in 1 blocks are definitely lost in loss record 57 of 80
==17332==    at 0x4841848: malloc (vg_replace_malloc.c:431)
==17332==    by 0x49F8699: xmlXPathWrapNodeSet (xpath.c:4400)
==17332==    by 0x4A072B2: xmlXPathNodeCollectAndTest (xpath.c:12555)
==17332==    by 0x4A05D29: xmlXPathCompOpEval (xpath.c:13111)
==17332==    by 0x4A06193: xmlXPathCompOpEval (xpath.c:13359)
==17332==    by 0x4A08E54: xmlXPathRunEval (xpath.c:13949)
==17332==    by 0x4A096E3: xmlXPathEval (xpath.c:14477)
==17332==    by 0x132533: NimMainModule (nimpath.nim:52)
==17332==    by 0x1350CA: NimMainInner (unittest.nim:242)
==17332==    by 0x1350DD: NimMain (unittest.nim:253)
==17332==    by 0x1350FF: main (unittest.nim:261)
...
==17332== LEAK SUMMARY:
==17332==    definitely lost: 858 bytes in 16 blocks
==17332==    indirectly lost: 32,959 bytes in 146 blocks
```

**after**
```
==17441== LEAK SUMMARY:
==17441==    definitely lost: 522 bytes in 16 blocks
==17441==    indirectly lost: 32,863 bytes in 140 blocks
```